### PR TITLE
Alias and deprecate `discover` and `provision`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MyScout.prototype.init = function(next) {
 ```
 
 ##### Method: Scout#discover(constructor, [arguments])
-**Deprecated: use `Scout#addToRegistry(constructor, [arguments])` instead.**
+Deprecated: use `Scout#addToRegistry(constructor, [arguments])` instead.
 
 ##### Method: Scout#addToRegistry(constructor, [arguments])
 
@@ -62,7 +62,7 @@ MyScout.prototype.init = function(next) {
 ```
 
 ##### Method: Scout#provision(deviceObject, constructor)
-**Deprecated: use `Scout#getFromRegistry(deviceObject, constructor)` instead.**
+Deprecated: use `Scout#getFromRegistry(deviceObject, constructor)` instead.
 
 ##### Method: Scout#getFromRegistry(deviceObject, constructor)
 

--- a/README.md
+++ b/README.md
@@ -45,29 +45,31 @@ MyScout.prototype.init = function(next) {
 ```
 
 ##### Method: Scout#discover(constructor, [arguments])
+**Deprecated: use `Scout#addToRegistry(constructor, [arguments])` instead.**
+
+##### Method: Scout#addToRegistry(constructor, [arguments])
 
 * `constructor` Subclass of Device
 * `arguments` List of Objects
 
-This method is called by you when you've found your device. The `constructor` argument should be a subclass of `Device`, and the second argument is a
-list of objects to be used by the constructor.
+This method is called by you when you're ready to initialize your device and add it to the registry. The `constructor` argument should be a subclass of `Device`, and the second argument is a list of objects to be used by the constructor.
 
 ```js
 MyScout.prototype.init = function(next) {
-  this.discover(MyDevice, foo, bar, 'baz');
+  this.addToRegistry(MyDevice, foo, bar, 'baz');
 };
 
 ```
 
-
-
 ##### Method: Scout#provision(deviceObject, constructor)
+**Deprecated: use `Scout#getFromRegistry(deviceObject, constructor)` instead.**
+
+##### Method: Scout#getFromRegistry(deviceObject, constructor)
 
 * `deviceObject` Object
 * `constructor` Subclass of Device
 
-Zetta will persist device data to an internal registry. Using an object retrieved from this registry you can initialize a device that Zetta already
-knows about. The first argument `deviceObject` is just data on the object from Zetta. The `constructor` argument is what will be created by Zetta.
+Zetta will persist device data to an internal registry. Using an object retrieved from this registry you can initialize a device that Zetta already knows about. The first argument `deviceObject` is just data on the object from Zetta. The `constructor` argument is what will be created by Zetta.
 
 ```js
 MyScout.prototype.init = function(next) {
@@ -76,7 +78,7 @@ MyScout.prototype.init = function(next) {
     id: '123',
     foo: 'bar'
   };
-  this.provision(deviceObject, MyDevice);
+  this.getFromRegistry(deviceObject, MyDevice);
 };
 ```
 
@@ -94,10 +96,10 @@ MyScout.prototype.init = function(next) {
   this.server.find(query, function(err, results) {
     if (results.length > 0) {
       // found in registry, tell zetta it came online
-      self.provision(results[0], MyDevice, foo, bar, 'baz');
+      self.getFromRegistry(results[0], MyDevice, foo, bar, 'baz');
     } else {
-      // does not exist in registry, discover a new one.
-      self.discover(MyDevice, foo, bar, 'baz');
+      // does not exist in registry, add the device to the registry
+      self.addToRegistry(MyDevice, foo, bar, 'baz');
     }
   });
 };

--- a/scout.js
+++ b/scout.js
@@ -15,7 +15,7 @@ Scout.prototype.createDevice = function(args) {
 };
 
 // add a new device to the registry
-Scout.prototype.discover = function(constructor) {
+Scout.prototype.addToRegistry = function(constructor) {
   var self = this;
   var machine = this.createDevice(arguments);  
   machine = Scientist.init(machine);
@@ -28,9 +28,9 @@ Scout.prototype.discover = function(constructor) {
   });
   return machine;
 };
-Scout.prototype.addToRegistry = Scout.prototype.discover;
+Scout.prototype.discover = util.deprecate(Scout.prototype.addToRegistry, '`discover` is deprecated, please use `addToRegistry`');
 
-Scout.prototype.provision = function(deviceObject, constructor) {
+Scout.prototype.getFromRegistry = function(deviceObject, constructor) {
 
   // if already initiated on runtime do not create a second instnace
   if(this.server._jsDevices[deviceObject.id]) {
@@ -55,4 +55,4 @@ Scout.prototype.provision = function(deviceObject, constructor) {
   this.server.emit('deviceready', machine);
   return machine;
 };
-Scout.prototype.getFromRegistry = Scout.prototype.provision;
+Scout.prototype.provision = util.deprecate(Scout.prototype.getFromRegistry, '`provision` is deprecated, please use `getFromRegistry`');

--- a/scout.js
+++ b/scout.js
@@ -28,6 +28,7 @@ Scout.prototype.discover = function(constructor) {
   });
   return machine;
 };
+Scout.prototype.addToRegistry = Scout.prototype.discover;
 
 Scout.prototype.provision = function(deviceObject, constructor) {
 
@@ -48,10 +49,10 @@ Scout.prototype.provision = function(deviceObject, constructor) {
   this.server._jsDevices[machine.id] = machine;
 
   this.server.registry.save(machine, function(err){
-
   });
 
   this.server._log.emit('log','scout', 'Device (' + machine.type + ') ' + machine.id + ' was provisioned from registry.' );
   this.server.emit('deviceready', machine);
   return machine;
 };
+Scout.prototype.getFromRegistry = Scout.prototype.provision;


### PR DESCRIPTION
The functions `discover` and `provision` on `Scout` are awesome. Powerful stuff, but the labels `discover` and `provision` are troublesome

A typical internal dialog goes like this:

> `discover` is the one that discovers an existing device within the registry, right? And `provision` is heavier duty one for a brand new device that provisions into the registry? Right? <Checks docs/> NO! It's the opposite. Ugh.

This pull request is meant for your consideration for v1 so that we can stop the `discover` and `provision` madness before we are saddled with it for a full dev cycle.

This pull request aliases `discover` as `addToRegistry` and aliases `provision` as `getFromRegistry`. It deprecates `discover` and `provision` with a warning in the code and a warning in the README. Below is the proposed versus current syntax.

PROPOSED SYNTAX:

```
if (results.length > 0) {
  self.getFromRegistry(results[0], PezDispenser, options);
} else {
  self.addToRegistry(PezDispenser, options);
}
```

CURRENT SYNTAX:

```
if (results.length > 0) {
  self.provision(results[0], PezDispenser, options);
} else {
  self.discover(PezDispenser, options);
}
```
